### PR TITLE
Add arm64 builds for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-11, macos-12, windows-2019]
+        arch: [x64]
         solver: [z3-4.8.5, z3-4.12.1]
+        include:
+          - os: macos-11
+            arch: arm64
+            solver: z3-4.12.1
+          - os: macos-12
+            arch: arm64
+            solver: z3-4.12.1
     steps:
       - name: Check out
         uses: actions/checkout@v3
@@ -38,16 +46,16 @@ jobs:
 
       - name: Build (non-Windows)
         shell: bash
-        run: scripts/build.sh ${{ matrix.solver }}
+        run: scripts/build.sh ${{ matrix.solver }} ${{ matrix.arch }}
         if: runner.os != 'Windows'
 
       - name: Build (Windows)
         shell: msys2 {0}
-        run: scripts/build.sh ${{ matrix.solver }}
+        run: scripts/build.sh ${{ matrix.solver }} ${{ matrix.arch }}
         if: runner.os == 'Windows'
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           path: bin
-          name: ${{ matrix.solver }}-${{ matrix.os }}-bin
+          name: ${{ matrix.solver }}-${{ matrix.arch }}-${{ matrix.os }}-bin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,6 +2,8 @@
 set -Eeuxo pipefail
 
 SOLVER=$1
+ARCH=$2
+
 BIN=$(pwd)/bin
 mkdir -p $BIN
 
@@ -16,12 +18,25 @@ case "$RUNNER_OS" in
     EXECUTABLE_EXT=".exe"
 esac
 
+case "$ARCH" in
+  arm64)
+    ARCH_OPT="--arm64=true"
+    ;;
+  *)
+    ARCH_OPT=""
+    ;;
+esac
+
 pushd repos/$SOLVER
 if [[ "$RUNNER_OS" == 'Windows' ]] ; then
   sed -i.bak -e 's/STATIC_BIN=False/STATIC_BIN=True/' scripts/mk_util.py
 fi
-python scripts/mk_make.py
+python scripts/mk_make.py $ARCH_OPT
 (cd build && make -j4 && cp z3$EXECUTABLE_EXT $BIN/$SOLVER$EXECUTABLE_EXT)
 strip $BIN/$SOLVER$EXECUTABLE_EXT
-$BIN/$SOLVER$EXECUTABLE_EXT --version
+
+if [[ "$ARCH" == 'x64' ]] ; then
+  $BIN/$SOLVER$EXECUTABLE_EXT --version
+fi
+
 popd


### PR DESCRIPTION
This is a PR for the changes proposed in https://github.com/dafny-lang/dafny/issues/4304. It adds arm64 builds for macOS 11 and 12 for z3-4.12.2. I've tried to add arm64 builds for Linux as well, but it is not possible to do using `mk_make.py` script alone: it seems one should use cmake directly instead. So, maybe next time.

Also I've changed the naming scheme of the generated artifacts: it now includes the arch of the binary. This requires changes to the Dafny code.

Btw, GitHub Actions matrix looks a bit convoluted now, but I wasn't able to find a simpler way of adding 2 specific builds into it.