### PR TITLE
Add ARM64 Windows Z3 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,12 @@ jobs:
           - os: macos-26
             arch: arm64
             solver: z3-4.15.4
+          - os: windows-11-arm
+            arch: arm64
+            solver: z3-4.14.1
+          - os: windows-11-arm
+            arch: arm64
+            solver: z3-4.15.4
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -62,7 +68,7 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Install dependencies (Windows)
+      - name: Install dependencies (Windows x64)
         uses: msys2/setup-msys2@v2
         with:
           update: true
@@ -74,17 +80,40 @@ jobs:
             mingw-w64-x86_64-ninja
             python
             tar
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.arch == 'x64'
+
+      - name: Setup Python (Windows ARM64)
+        if: runner.os == 'Windows' && matrix.arch == 'arm64'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Build (non-Windows)
         shell: bash
         run: scripts/build.sh ${{ matrix.solver }} ${{ matrix.arch }}
         if: runner.os != 'Windows'
 
-      - name: Build (Windows)
+      - name: Build (Windows x64)
         shell: msys2 {0}
         run: scripts/build.sh ${{ matrix.solver }} ${{ matrix.arch }}
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.arch == 'x64'
+
+      - name: Build (Windows ARM64)
+        if: runner.os == 'Windows' && matrix.arch == 'arm64'
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
+          cd repos\${{ matrix.solver }}
+          mkdir build
+          cd build
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DZ3_BUILD_LIBZ3_SHARED=OFF -DZ3_USE_LIB_GMP=OFF -DZ3_BUILD_DOTNET_BINDINGS=OFF -DZ3_BUILD_JAVA_BINDINGS=OFF -DZ3_BUILD_PYTHON_BINDINGS=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded ..
+          ninja shell
+          mkdir ..\..\..\bin
+          copy z3.exe ..\..\..\bin\${{ matrix.solver }}.exe
+
+      - name: Verify (Windows ARM64)
+        if: runner.os == 'Windows' && matrix.arch == 'arm64'
+        run: bin\${{ matrix.solver }}.exe --version
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/Z3Prover/z3.git
 [submodule "repos/z3-4.15.4"]
 	path = repos/z3-4.15.4
-	url = git@github.com:Z3Prover/z3.git
+	url = https://github.com/Z3Prover/z3.git


### PR DESCRIPTION
## Changes

### ARM64 Windows Z3 builds
- Add `windows-11-arm` matrix entries for Z3 4.14.1 and 4.15.4
- Build natively on ARM64 Windows runner using MSVC + CMake + Ninja
- Produces a static `z3.exe` with no DLL dependencies
- Includes verification step (`z3 --version`) to confirm the binary works
- Z3 4.12.1 and 4.12.6 are not included (no ARM64 Windows support upstream)

### Other
- Fix z3-4.15.4 submodule URL from SSH to HTTPS (consistent with other submodules)

### Motivation
This is needed for [dafny-lang/dafny#6452](https://github.com/dafny-lang/dafny/pull/6452) which adds ARM64 Windows Dafny releases. The Dafny release zip bundles Z3 4.12.1 (x64 fallback, no ARM64 build exists) and Z3 4.14.1 (native ARM64 from this PR).